### PR TITLE
Introduce VectorStore abstraction

### DIFF
--- a/Architektur.md
+++ b/Architektur.md
@@ -25,13 +25,13 @@ AGENT_DATA_DIR – optional directory for persistent data (defaults to ./data)
 Der Code liest diese Variablen in `investment_agents.py` ein und setzt eine `Retry`‑Konfiguration für HTTP‑Aufrufe【F:investment_agents.py†L57-L82】.
 Es wird ein OpenAI‑Client erstellt und eine `requests`‑Session mit Retry‑Adapter konfiguriert.【F:investment_agents.py†L76-L81】.
 
-Lokale Daten (Reports, FAISS‑Index und Metadaten) werden im Verzeichnis `AGENT_DATA_DIR` abgelegt. Existiert dort bereits ein Index, wird er geladen, andernfalls neu erstellt.【F:investment_agents.py†L128-L143】.
+Lokale Daten (Reports, FAISS‑Index und Metadaten) werden im Verzeichnis `AGENT_DATA_DIR` abgelegt. Existiert dort bereits ein Index, wird er geladen, andernfalls neu erstellt.【F:investment_agents.py†L129-L140】.
 
 ## 3. Hilfsfunktionen
 - `_embed(text)` erzeugt ein normalisiertes Embedding via OpenAI und nutzt LRU‑Caching, um wiederholte Anfragen zu vermeiden.【F:investment_agents.py†L149-L158】
 - `_extract_pdf(path)` lädt ein PDF seitenweise hoch, ruft GPT‑Vision zur Textextraktion auf und fügt die Ergebnisse zusammen.【F:investment_agents.py†L161-L202】
 - `web_search(query)` führt eine Google‑Suche über SerpAPI durch und gibt die Top‑Ergebnisse zurück.【F:investment_agents.py†L208-L217】
-- `vector_memory_impl(...)` stellt einen persistenten Vektor‑Speicher bereit: Embeddings können hinzugefügt, abgefragt oder gelistet werden.【F:investment_agents.py†L220-L243】
+- `vector_memory_impl(...)` stellt einen persistenten Vektor‑Speicher bereit: Embeddings können hinzugefügt, abgefragt oder gelistet werden.【F:investment_agents.py†L220-L244】
 
 Diese Funktionen werden mithilfe von `function_tool` als Tools für die Agenten registriert (z.B. `parse_pdf`, `web_search`, `vector_memory_tool`).
 
@@ -53,7 +53,7 @@ Die zentrale Funktion `evaluate(pdf, project)` steuert den Ablauf:
 2. Alle Spezialagenten werden parallel über `Runner.run` auf diesen Text angewendet.【F:investment_agents.py†L317-L320】
 3. Anschließend wird das zusammengesetzte Ergebnis vom `ReportAgent` in ein JSON‑Objekt verwandelt. Falls das JSON nicht direkt geparst werden kann, wird per Regex nachgeholfen.【F:investment_agents.py†L325-L340】
 4. Der `SupervisorAgent` erhält die aktuelle Zusammenfassung sowie vergangene Ergebnisse aus dem Vektorspeicher, um eine Entscheidung zu treffen (YES/NO) und ggf. eine Begründung auszugeben.【F:investment_agents.py†L342-L349】
-5. Das Resultat wird im FAISS‑Vektorstore gespeichert und ein HTML‑Bericht über Jinja2 erzeugt. Der Pfad zum Bericht wird im Rückgabewert festgehalten.【F:investment_agents.py†L355-L367】
+5. Das Resultat wird im FAISS‑Vektorstore gespeichert und ein HTML‑Bericht über Jinja2 erzeugt. Der Pfad zum Bericht wird im Rückgabewert festgehalten.【F:investment_agents.py†L357-L368】
 
 Diese Funktion dient ebenfalls als CLI‑Entry‑Point und kann direkt mit `python investment_agents.py <pdf> <projektname>` aufgerufen werden. Ein Fallback sorgt dafür, dass auch in Umgebungen mit bereits laufendem Event‑Loop (z.B. Jupyter) ausgeführt werden kann.【F:investment_agents.py†L372-L389】
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ The PDF path is the first argument and `test` is the project name used to store
 the results. Generated HTML reports are written to `data/reports/<project>.html`.
 
 HTML output is rendered via a small Jinja2 template to ensure proper escaping and maintainability.
+
+The embedding memory is handled through `vector_store.VectorStore`, which currently wraps a FAISS index. This abstraction allows alternative backends to be plugged in easily.

--- a/vector_store.py
+++ b/vector_store.py
@@ -1,0 +1,53 @@
+import os
+import json
+from typing import Any, Dict, List
+
+import faiss
+import numpy as np
+
+
+class VectorStore:
+    """Simple wrapper around a FAISS index with JSON metadata."""
+
+    def __init__(self, index_path: str, meta_path: str, embed_dim: int) -> None:
+        self.index_path = index_path
+        self.meta_path = meta_path
+        self.embed_dim = embed_dim
+        self.index: faiss.Index | None = None
+        self.metadata: List[Dict[str, Any]] = []
+
+    def load(self) -> None:
+        """Load index and metadata from disk, creating new store if missing."""
+        if os.path.exists(self.index_path) and os.path.exists(self.meta_path):
+            self.index = faiss.read_index(self.index_path)
+            self.metadata = json.loads(open(self.meta_path).read())
+        else:
+            self.index = faiss.IndexIDMap(faiss.IndexFlatIP(self.embed_dim))
+            self.metadata = []
+
+    def save(self) -> None:
+        """Persist index and metadata to disk."""
+        if self.index is None:
+            return
+        faiss.write_index(self.index, self.index_path)
+        open(self.meta_path, "w").write(json.dumps(self.metadata, indent=2))
+
+    def add(self, vector: np.ndarray, meta: Dict[str, Any]) -> None:
+        """Add ``vector`` with ``meta`` information to the store."""
+        if self.index is None:
+            raise ValueError("VectorStore not initialised")
+        vec_id = len(self.metadata)
+        self.index.add_with_ids(np.expand_dims(vector, 0), np.array([vec_id]))
+        self.metadata.append(meta)
+        self.save()
+
+    def query(self, vector: np.ndarray, k: int = 3) -> List[Dict[str, Any]]:
+        """Return ``k`` nearest neighbours for ``vector``."""
+        if self.index is None:
+            raise ValueError("VectorStore not initialised")
+        D, I = self.index.search(np.expand_dims(vector, 0), k)
+        return [self.metadata[i] for i in I[0] if i != -1]
+
+    def list(self) -> List[Dict[str, Any]]:
+        """Return all stored metadata."""
+        return self.metadata


### PR DESCRIPTION
## Summary
- implement a new `vector_store.py` module wrapping FAISS
- replace inline FAISS handling in `investment_agents.py` with VectorStore usage
- adapt tests to new abstraction
- document VectorStore in README and architecture doc

## Testing
- `pytest -q`