### PR TITLE
Switch report generation to Markdown

### DIFF
--- a/Architektur.md
+++ b/Architektur.md
@@ -11,7 +11,7 @@ Die Datei `requirements.txt` listet alle benutzten Pakete. Wichtig sind insbeson
 - `PyPDF2` – Einlesen und Aufteilen von PDF‑Dokumenten.
 - `requests` und `urllib3` – HTTP‑Requests inkl. Retry‑Policy für SerpAPI.
 - `numpy` – Verarbeitung numerischer Daten und Embeddings.
-- `Jinja2` – Rendering des finalen HTML‑Berichts.
+- Markdown wird direkt geschrieben, es wird kein Templating benötigt.
 - `nest_asyncio` – Ermöglicht verschachtelte Event‑Loops (z.B. in Jupyter).
 
 ## 2. Konfiguration und Initialisierung
@@ -42,7 +42,7 @@ Es existieren mehrere spezialisierte Agenten, definiert über das Agents SDK:
 - `MarketOpportunityAgent` – analysiert Markt und Wettbewerb.
 - `RiskAssessmentAgent` – identifiziert finanzielle und operative Risiken.
 - `AlveusFitAgent` – prüft projektspezifische Kriterien.
-- `ReportAgent` – fasst die Resultate in einem schlanken JSON zusammen.
+ - `ReportAgent` – erzeugt einen Markdown‑Bericht aus allen Ergebnissen.
 - `SupervisorAgent` – bewertet die Ergebnisse und entscheidet YES/NO bzw. fordert einen RETRY an.
 
 Jeder Agent erhält eine Instruktion und je nach Bedarf Zugriff auf bestimmte Tools (PDF‑Parser, Websuche, Vektorspeicher). Die Definitionen sind in den Zeilen 252‑271 zu finden.【F:investment_agents.py†L252-L271】
@@ -51,9 +51,9 @@ Jeder Agent erhält eine Instruktion und je nach Bedarf Zugriff auf bestimmte To
 Die zentrale Funktion `evaluate(pdf, project)` steuert den Ablauf:
 1. Das PDF wird mit `_extract_pdf` in reinen Text umgewandelt.
 2. Alle Spezialagenten werden parallel über `Runner.run` auf diesen Text angewendet.【F:investment_agents.py†L317-L320】
-3. Anschließend wird das zusammengesetzte Ergebnis vom `ReportAgent` in ein JSON‑Objekt verwandelt. Falls das JSON nicht direkt geparst werden kann, wird per Regex nachgeholfen.【F:investment_agents.py†L325-L340】
-4. Der `SupervisorAgent` erhält die aktuelle Zusammenfassung sowie vergangene Ergebnisse aus dem Vektorspeicher, um eine Entscheidung zu treffen (YES/NO) und ggf. eine Begründung auszugeben.【F:investment_agents.py†L342-L349】
-5. Das Resultat wird im FAISS‑Vektorstore gespeichert und ein HTML‑Bericht über Jinja2 erzeugt. Der Pfad zum Bericht wird im Rückgabewert festgehalten.【F:investment_agents.py†L357-L368】
+3. Die Ergebnisse werden dem `SupervisorAgent` vorgelegt, der eine Entscheidung trifft (YES/NO) und eine Begründung liefert.【F:investment_agents.py†L331-L343】
+4. Anschließend erstellt der `ReportAgent` daraus einen Markdown‑Bericht.【F:investment_agents.py†L345-L349】
+5. Das Resultat wird im FAISS‑Vektorstore gespeichert und der Markdown‑Bericht abgelegt. Der Pfad zum Bericht wird im Rückgabewert festgehalten.【F:investment_agents.py†L350-L361】
 
 Diese Funktion dient ebenfalls als CLI‑Entry‑Point und kann direkt mit `python investment_agents.py <pdf> <projektname>` aufgerufen werden. Ein Fallback sorgt dafür, dass auch in Umgebungen mit bereits laufendem Event‑Loop (z.B. Jupyter) ausgeführt werden kann.【F:investment_agents.py†L372-L389】
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ python investment_agents.py ./KPIs.pdf test
 ```
 
 The PDF path is the first argument and `test` is the project name used to store
-the results. Generated HTML reports are written to `data/reports/<project>.html`.
+the results. Generated Markdown reports are written to `data/reports/<project>.md`.
 
-HTML output is rendered via a small Jinja2 template to ensure proper escaping and maintainability.
+The final report is created directly in Markdown without any HTML templating.
 
 The embedding memory is handled through `vector_store.VectorStore`, which currently wraps a FAISS index. This abstraction allows alternative backends to be plugged in easily.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,7 @@ urllib3                # für Retry-Adapter (requests bringt es intern mit, aber
 numpy
 
 # Templating
-Jinja2
-
-PyPDF2
+# (nicht mehr benötigt)
 
 asyncio
 nest_asyncio

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -29,7 +29,7 @@ def fake_run_sync(agent, text):
         def __init__(self, out):
             self.final_output = out
     if agent.name == 'ReportAgent':
-        return Res('{"summary":"s","keywords":["k"],"metrics":{"m":1}}')
+        return Res('# Summary\ns\n\n# Keywords\n- k\n\n# Metrics\n- m: 1\n\n# Decision\nYES\n\n# Rationale\nall good')
     if agent.name == 'SupervisorAgent':
         return Res('YES\nall good')
     return Res(f'result from {agent.name}')
@@ -40,7 +40,7 @@ async def fake_run_async(agent, text):
     return fake_run_sync(agent, text)
 
 
-def test_evaluate_creates_html(tmp_path, monkeypatch):
+def test_evaluate_creates_markdown(tmp_path, monkeypatch):
     setup_simple_env(tmp_path, monkeypatch)
     monkeypatch.setattr(ia, '_extract_pdf', lambda pdf: 'text')
     monkeypatch.setattr(ia.Runner, 'run_sync', staticmethod(fake_run_sync))
@@ -48,9 +48,9 @@ def test_evaluate_creates_html(tmp_path, monkeypatch):
     result = asyncio.run(ia.evaluate('dummy.pdf', 'proj1'))
     assert result.summary == 's'
     assert result.decision == 'YES'
-    assert os.path.exists(result.html)
-    with open(result.html, 'r', encoding='utf-8') as fh:
-        assert '<html>' in fh.read()
+    assert os.path.exists(result.markdown)
+    with open(result.markdown, 'r', encoding='utf-8') as fh:
+        assert '# Summary' in fh.read()
 
 
 def test_vector_memory_add_query_list(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- rewrite ReportAgent to return Markdown instead of JSON/HTML
- create helper functions to parse Markdown sections
- generate Markdown report in `evaluate` and store the path
- update `EvaluationResult` dataclass
- adjust tests and docs for Markdown output
- clean up requirements

## Testing
- `pytest -q`